### PR TITLE
Moving formatting of columns and table to corresponding classes and outside of WhaleLoader

### DIFF
--- a/pipelines/tests/unit/models/test_table_metadata.py
+++ b/pipelines/tests/unit/models/test_table_metadata.py
@@ -1,0 +1,40 @@
+import logging
+import unittest
+
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
+
+class TestTableMetadata(unittest.TestCase):
+    def setUp(self) -> None:
+        logging.basicConfig(level=logging.INFO)
+
+    def test_format_for_markdown(self):
+        table_metadata = TableMetadata(
+            database='test_database',
+            cluster='test_cluster',
+            schema='test_schema',
+            name='test_table',
+            columns=[
+                ColumnMetadata(
+                    name='test_column_1',
+                    data_type='INTEGER',
+                    sort_order=1,
+                ),
+                ColumnMetadata(
+                    name='test_column_2',
+                    data_type='BOOLEAN',
+                    sort_order=2,
+                ),
+            ],
+        )
+
+        expected = """# `test_schema.test_table`
+`test_database` | `test_cluster`
+
+## Column details
+* [INTEGER]   `test_column_1`
+* [BOOLEAN]   `test_column_2`
+"""
+
+        self.assertEqual(table_metadata.format_for_markdown(), expected)
+

--- a/pipelines/whale/loader/whale_loader.py
+++ b/pipelines/whale/loader/whale_loader.py
@@ -193,7 +193,7 @@ def _get_section_from_watermarks(watermarks):
 
 
 def _update_table_metadata(sections, record):
-    table_metadata_blob = format_table_metadata(record)
+    table_metadata_blob = record.format_for_markdown()
 
     table_details = re.split(COLUMN_DETAILS_DELIMITER, table_metadata_blob)
     header = table_details[0]
@@ -221,90 +221,6 @@ def _update_metric(sections, record):
     new_section = _get_section_from_metrics(metrics_dict)
     sections[METRICS_SECTION] = format_yaml_section(new_section, METRICS_DELIMITER)
     return sections
-
-
-def format_table_metadata(record) -> metadata_model_whale.TableMetadata:
-    block_template = textwrap.dedent(
-        """        # `{schema_statement}{name}`{view_statement}
-        `{database}`{cluster_statement}
-        {description}
-        {column_details_delimiter}
-        {columns}
-        """
-    )
-
-    formatted_columns = format_columns(record)
-
-    if record.description:
-        if type(record.description) == DescriptionMetadata:
-            description = record.description._text + "\n"
-        else:
-            description = str(record.description) + "\n"
-    else:
-        description = ""
-
-    if record.cluster == "None":  # edge case for Hive Metastore
-        cluster = None
-    else:
-        cluster = record.cluster
-
-    if cluster is not None:
-        cluster_statement = f" | `{cluster}`"
-    else:
-        cluster_statement = ""
-
-    if (
-        record.schema == None
-    ):  # edge case for Glue, which puts everything in record.table
-        schema_statement = ""
-    else:
-        schema_statement = f"{record.schema}."
-
-    markdown_blob = block_template.format(
-        schema_statement=schema_statement,
-        name=record.name,
-        view_statement=" [view]" if record.is_view else "",
-        database=record.database,
-        cluster_statement=cluster_statement,
-        description=description,
-        column_details_delimiter=COLUMN_DETAILS_DELIMITER,
-        columns=formatted_columns,
-    )
-
-    return markdown_blob
-
-
-def format_columns(record) -> str:
-    max_type_length = 9
-    columns = record.columns
-
-    if not columns:
-        return ""
-
-    column_template_no_desc = "* {buffered_type} `{name}`"
-    column_template = column_template_no_desc + "\n  - {description}"
-    formatted_columns_list = []
-
-    for column in columns:
-        buffer_length = max(max_type_length - len(column.type), 0)
-        buffered_type = "[" + column.type + "]" + " " * buffer_length
-
-        if column.description:
-            formatted_column_text = column_template.format(
-                buffered_type=buffered_type,
-                name=column.name,
-                description=column.description,
-            )
-        else:
-            formatted_column_text = column_template_no_desc.format(
-                buffered_type=buffered_type,
-                name=column.name,
-            )
-
-        formatted_columns_list.append(formatted_column_text)
-
-    formatted_columns = "\n".join(formatted_columns_list)
-    return formatted_columns
 
 
 def _get_metrics_from_section(section):

--- a/pipelines/whale/models/column_metadata.py
+++ b/pipelines/whale/models/column_metadata.py
@@ -1,4 +1,5 @@
 from typing import Dict, Iterable, List, Optional, Union
+from whale.utils.markdown_delimiters import COLUMN_DETAILS_DELIMITER
 
 class ColumnMetadata:
     COLUMN_KEY_FORMAT = "{db}://{cluster}.{schema}.{tbl}/{col}"
@@ -6,9 +7,9 @@ class ColumnMetadata:
     def __init__(
         self,
         name: str,
-        description: Optional[str],
         data_type: str,
         sort_order: int,
+        description: Optional[str] = None,
         tags: Optional[Union[List[Dict], List[str]]] = None,
         is_partition_column: Optional[bool] = None,
     ):
@@ -25,6 +26,29 @@ class ColumnMetadata:
         self.sort_order = sort_order
         self.tags = tags
         self.is_partition_column = is_partition_column
+
+
+    def format_for_markdown(self):
+        max_type_length = 9
+
+        self.template_no_desc = "* {buffered_type} `{name}`"
+        self.template = self.template_no_desc + "\n  - {description}"
+
+        buffer_length = max(max_type_length - len(self.type), 0)
+        buffered_type = "[" + self.type + "]" + " " * buffer_length
+
+        if self.description:
+            return self.template.format(
+                buffered_type=buffered_type,
+                name=self.name,
+                description=self.description,
+            )
+        else:
+            return self.template_no_desc.format(
+                buffered_type=buffered_type,
+                name=self.name,
+            )
+
 
     def __repr__(self):
         # type: () -> str

--- a/pipelines/whale/models/table_metadata.py
+++ b/pipelines/whale/models/table_metadata.py
@@ -1,6 +1,9 @@
 import copy
 from typing import Dict, Iterable, List, Optional, Union
+import textwrap
+from databuilder.models.table_metadata import DescriptionMetadata
 from whale.models.column_metadata import ColumnMetadata
+from whale.utils.markdown_delimiters import COLUMN_DETAILS_DELIMITER
 
 class TableMetadata(object):
     """
@@ -60,6 +63,59 @@ class TableMetadata(object):
 
         if kwargs:
             self.attrs = copy.deepcopy(kwargs)
+
+
+    def format_for_markdown(self):
+        block_template = textwrap.dedent(
+            """        # `{schema_statement}{name}`{view_statement}
+        `{database}`{cluster_statement}
+        {description}
+        {column_details_delimiter}
+        {columns}
+            """
+        )
+
+        formatted_columns_list = [column.format_for_markdown() for column in self.columns]
+        formatted_columns = "\n".join(formatted_columns_list)
+
+        if self.description:
+            if type(self.description) == DescriptionMetadata:
+                description = self.description._text + "\n"
+            else:
+                description = str(self.description) + "\n"
+        else:
+            description = ""
+
+        if self.cluster == "None":  # edge case for Hive Metastore
+            cluster = None
+        else:
+            cluster = self.cluster
+
+        if cluster is not None:
+            cluster_statement = f" | `{cluster}`"
+        else:
+            cluster_statement = ""
+
+        if (
+            self.schema == None
+        ):  # edge case for Glue, which puts everything in self.table
+            schema_statement = ""
+        else:
+            schema_statement = f"{self.schema}."
+
+        markdown_blob = block_template.format(
+            schema_statement=schema_statement,
+            name=self.name,
+            view_statement=" [view]" if self.is_view else "",
+            database=self.database,
+            cluster_statement=cluster_statement,
+            description=description,
+            column_details_delimiter=COLUMN_DETAILS_DELIMITER,
+            columns=formatted_columns,
+        )
+
+        return markdown_blob
+
 
     def __repr__(self):
         # type: () -> str


### PR DESCRIPTION
This PR moves formatting of columns and table for the markdown files outside of `WhaleLoader` and into `ColumnMetadata` and `TableMetadata`.